### PR TITLE
feat: monitor cloud connections and reconnect if necessary

### DIFF
--- a/src/conf.d/tedge-monitoring.conf
+++ b/src/conf.d/tedge-monitoring.conf
@@ -18,3 +18,65 @@ check process mosquitto with pidfile /var/run/mosquitto/mosquitto.pid
 # repositories.
 check process tedge-agent with pidfile /run/lock/tedge-agent.lock
     if memory usage > 10 MB for 10 cycles then exec "/usr/bin/monit-tedge-message event tedge-agent_mem_hi"
+
+
+########################################################################
+# Monitor cloud connections
+########################################################################
+#
+# <mapper>-enabled  - Checks if the mapper is activated
+# <mapper>-connectivity - Checks if the mapper is connected or not, and reconnects it if required
+#
+# Note: If the path needs to use double quotes, use the hex value \0x22 instead
+#
+
+#
+# Cumulocity IoT
+#
+check program c8y-enabled with path "/usr/bin/tedge config get c8y.url"
+    with timeout 5 seconds
+    every 2 cycles
+    if content != ".+" then unmonitor
+    group c8y
+
+check program c8y-connectivity with path "/usr/bin/tedge connect c8y --test"
+   with timeout 60 seconds
+   every 2 cycles
+   if status != 0 then alert
+   if status != 0 for 10 cycles then exec "/usr/bin/tedge reconnect c8y"
+   depends on c8y-enabled
+   group c8y
+
+#
+# Azure IoT
+#
+check program az-enabled with path "/usr/bin/tedge config get az.url"
+    with timeout 5 seconds
+    every 2 cycles
+    if content != ".+" then unmonitor
+    group az
+
+check program az-connectivity with path "/usr/bin/tedge connect az --test"
+   with timeout 60 seconds
+   every 2 cycles
+   if status != 0 then alert
+   if status != 0 for 10 cycles then exec "/usr/bin/tedge reconnect az"
+   depends on az-enabled
+   group az
+
+#
+# AWS
+#
+check program aws-enabled with path "/usr/bin/tedge config get aws.url"
+    with timeout 5 seconds
+    every 2 cycles
+    if content != ".+" then unmonitor
+    group aws
+
+check program aws-connectivity with path "/usr/bin/tedge connect aws --test"
+   with timeout 60 seconds
+   every 2 cycles
+   if status != 0 then alert
+   if status != 0 for 10 cycles then exec "/usr/bin/tedge reconnect aws"
+   depends on aws-enabled
+   group aws


### PR DESCRIPTION
If a cloud connector is configured, then periodically check if the connection is valid, and if not, reconnect the mapper.