### PR TITLE
feat: disable authentication for localhost connection to allow viewing website via remote access in the c8y ui

### DIFF
--- a/src/conf.d/tedge.conf
+++ b/src/conf.d/tedge.conf
@@ -4,4 +4,4 @@ set httpd port 2812 and
     # Alterative option, allow other devices to connect the endpoing in the local network
     #use address 0.0.0.0     # Dev only, otherwise use 'localhost'
     #allow 192.168.178.0/255.255.255.0   # Only allow local devices on the same network
-    allow admin:monit      # require user 'admin' with password 'monit'
+    #allow admin:monit      # require user 'admin' with password 'monit'


### PR DESCRIPTION
Removing the authentication for localhost connections allows the port 2812 to be used with the [cumulocity-remote-access-cloud-http-proxy](https://github.com/SoftwareAG/cumulocity-remote-access-cloud-http-proxy) project to display the monit UI from within the Cumulocity IoT UI.