### PR TITLE
fix(cloud): unmonitor cloud connection based on inclusive filter

### DIFF
--- a/src/conf.d/tedge-monitoring.conf
+++ b/src/conf.d/tedge-monitoring.conf
@@ -36,7 +36,7 @@ check process tedge-agent with pidfile /run/lock/tedge-agent.lock
 check program c8y-enabled with path "/usr/bin/tedge config get c8y.url"
     with timeout 5 seconds
     every 2 cycles
-    if content != ".+" then unmonitor
+    if content = ".*is not set.*" then unmonitor
     group c8y
 
 check program c8y-connectivity with path "/usr/bin/tedge connect c8y --test"
@@ -53,7 +53,7 @@ check program c8y-connectivity with path "/usr/bin/tedge connect c8y --test"
 check program az-enabled with path "/usr/bin/tedge config get az.url"
     with timeout 5 seconds
     every 2 cycles
-    if content != ".+" then unmonitor
+    if content = ".*is not set.*" then unmonitor
     group az
 
 check program az-connectivity with path "/usr/bin/tedge connect az --test"
@@ -70,7 +70,7 @@ check program az-connectivity with path "/usr/bin/tedge connect az --test"
 check program aws-enabled with path "/usr/bin/tedge config get aws.url"
     with timeout 5 seconds
     every 2 cycles
-    if content != ".+" then unmonitor
+    if content = ".*is not set.*" then unmonitor
     group aws
 
 check program aws-connectivity with path "/usr/bin/tedge connect aws --test"


### PR DESCRIPTION
Match against the output to check for the "is not set" string as the content is checked against both stdout and stderr