### PR TITLE
fix(mosquitto): use process matching to detect mosquitto

### DIFF
--- a/src/conf.d/tedge-monitoring.conf
+++ b/src/conf.d/tedge-monitoring.conf
@@ -10,7 +10,10 @@ check system $HOST
 # Service level monitoring
 #
 # Don't bother trying to send a message to MQTT is MQTT is failing ;)
-check process mosquitto with pidfile /var/run/mosquitto/mosquitto.pid
+
+# match against mosquitto service so it does not rely on the mosquitto.pid which is not
+# always used in all installations
+check process mosquitto MATCHING "mosquitto -c .+"
     if failed port 1883 protocol mqtt then alert
 
 # Note: the tedge-agent memory usage can spike when using package managed such as apt as


### PR DESCRIPTION
Not all mosquitto installations use a pid file so it is more reliable to use process based detection as it works in all situations.