### PR TITLE
fix(install): configure monitrc to only look for *.conf files

### DIFF
--- a/src/packaging/postinstall
+++ b/src/packaging/postinstall
@@ -21,7 +21,7 @@ do_systemd() {
 if [ -f /etc/monitrc ]; then
     if ! grep -q "include /etc/monit/conf.d/\*" /etc/monitrc; then
         echo "Adding /etc/monit/conf.d/ to the monit config (/etc/monitrc)" >&2
-        echo 'include /etc/monit/conf.d/*' >> /etc/monitrc
+        echo 'include /etc/monit/conf.d/*.conf' >> /etc/monitrc
     fi
 fi
 


### PR DESCRIPTION
dpkg can leave artifacts in the folder when upgrading the .conf files (artifacts from dpkg keepold/keepnew settings).

Avoid such problems by being more selective with which files are included.