### PR TITLE
fix(config): make tedge-monitoring.conf compatible with monit < 5.34.0

### DIFF
--- a/src/conf.d/tedge-monitoring.conf
+++ b/src/conf.d/tedge-monitoring.conf
@@ -37,10 +37,10 @@ check process tedge-agent with pidfile /run/lock/tedge-agent.lock
 #
 # Cumulocity IoT
 #
-check program c8y-enabled with path "/usr/bin/tedge config get c8y.url"
+check program c8y-enabled with path "/bin/sh -c '[ -n \0x22$(tedge config get c8y.url)\0x22 ]'"
     with timeout 5 seconds
     every 2 cycles
-    if content = ".*is not set.*" then unmonitor
+    if status != 0 then unmonitor
     group c8y
 
 check program c8y-connectivity with path "/usr/bin/tedge connect c8y --test"
@@ -54,10 +54,10 @@ check program c8y-connectivity with path "/usr/bin/tedge connect c8y --test"
 #
 # Azure IoT
 #
-check program az-enabled with path "/usr/bin/tedge config get az.url"
+check program az-enabled with path "/bin/sh -c '[ -n \0x22$(tedge config get az.url)\0x22 ]'"
     with timeout 5 seconds
     every 2 cycles
-    if content = ".*is not set.*" then unmonitor
+    if status != 0 then unmonitor
     group az
 
 check program az-connectivity with path "/usr/bin/tedge connect az --test"
@@ -71,10 +71,10 @@ check program az-connectivity with path "/usr/bin/tedge connect az --test"
 #
 # AWS
 #
-check program aws-enabled with path "/usr/bin/tedge config get aws.url"
+check program aws-enabled with path "/bin/sh -c '[ -n \0x22$(tedge config get aws.url)\0x22 ]'"
     with timeout 5 seconds
     every 2 cycles
-    if content = ".*is not set.*" then unmonitor
+    if status != 0 then unmonitor
     group aws
 
 check program aws-connectivity with path "/usr/bin/tedge connect aws --test"


### PR DESCRIPTION
The `content` key is introduced in the monit version 5.34.0. 
However, the debian 11 apt repository installs monit version 5.27.2. So, remove the usage of `content` to keep it compatible old version of monit.

Resolves Issue #11 