### PR TITLE
ci: fix report upload path

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -98,5 +98,5 @@ jobs:
         if: ${{ always() && github.event_name == 'pull_request_target' }}
         uses: joonvena/robotframework-reporter-action@v2.5
         with:
-          report_path: reports-${{ matrix.job.image }}
+          report_path: output
           gh_access_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fix the source path for the robot framework report when it is published to the PR (as a comment)