### PR TITLE
Fix ubuntu 20.04 and 24.04 compatibility

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,6 +41,9 @@ jobs:
         job:
           - { image: debian-11 }
           - { image: debian-12 }
+          - { image: ubuntu-20.04 }
+          - { image: ubuntu-22.04 }
+          - { image: ubuntu-24.04 }
 
     steps:
       - name: Checkout

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -27,6 +27,16 @@ contents:
     dst: /etc/monit/conf.d/tedge.conf
     type: symlink
 
+  # Optional service definition which has compatible capability settings
+  # otherwise the reconnect command will fail
+  # See https://salsa.debian.org/debian/monit/-/blob/debian/main/debian/patches/040_hardening-monit.service.patch?ref_type=heads
+  - src: ./src/service/monit.service
+    dst: /usr/share/tedge-monit-setup/service/
+    file_info:
+      mode: 0644
+      group: root
+      owner: root
+
   - src: ./src/tedge-monit-setup/env
     dst: /etc/tedge-monit-setup/env
     type: config|noreplace

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -27,10 +27,6 @@ contents:
     dst: /etc/monit/conf.d/tedge.conf
     type: symlink
 
-  - src: /usr/share/tedge-monit-setup/tedge-monitoring.conf
-    dst: /etc/monit/conf.d/tedge-monitoring.conf
-    type: symlink
-
   - src: ./src/tedge-monit-setup/env
     dst: /etc/tedge-monit-setup/env
     type: config|noreplace

--- a/src/conf.d/tedge-monitoring-legacy.conf
+++ b/src/conf.d/tedge-monitoring-legacy.conf
@@ -1,11 +1,9 @@
-# compatible with monit >= 5.27
-#
+# compatible with monit >= 5.26
 # System monitoring
 #
 check system $HOST
     if memory usage >= 90% for 1 cycles then exec "/usr/bin/monit-tedge-message event system_mem_hi"
     if loadavg (5min) per core > 1.5 for 10 cycles then exec "/usr/bin/monit-tedge-message event system_loadavg_hi"
-    if filedescriptors >= 90% then exec "/usr/bin/monit-tedge-message event system_fd_hi"
 
 #
 # Service level monitoring

--- a/src/packaging/postinstall
+++ b/src/packaging/postinstall
@@ -60,6 +60,15 @@ if [ -f "$MONITRC" ]; then
     fi
 fi
 
+# newer monit service definitions are sometimes too strict on the "hardening" of the service
+# which results in the "tedge reconnect c8y" command failing.
+if grep -q "CapabilityBoundingSet=" /usr/lib/systemd/system/monit.service; then
+    if [ ! -e /etc/systemd/system/monit.service ]; then
+        echo "Using custom monit.service definition with custom capabilities set"
+        ln -sf /usr/share/tedge-monit-setup/service/monit.service /etc/systemd/system/monit.service
+    fi
+fi
+
 do_initd() {
     if command -V chkconfig >/dev/null 2>&1; then
         chkconfig --add monit ||:

--- a/src/packaging/postinstall
+++ b/src/packaging/postinstall
@@ -16,12 +16,47 @@ do_systemd() {
     fi
 }
 
+MONITRC=/etc/monit/monitrc
+if [ -f /etc/monitrc ]; then
+    MONITRC=/etc/monitrc
+fi
+
 # In Yocto, monit looks at the /etc/monit.d/ directory
 # instead of /etc/monit/conf.d/, so let's add the other directory to as well (for normalization)
-if [ -f /etc/monitrc ]; then
-    if ! grep -q "include /etc/monit/conf.d/\*" /etc/monitrc; then
-        echo "Adding /etc/monit/conf.d/ to the monit config (/etc/monitrc)" >&2
-        echo 'include /etc/monit/conf.d/*.conf' >> /etc/monitrc
+if [ -f "$MONITRC" ]; then
+    if ! grep -q "include /etc/monit/conf.d/\*" "$MONITRC"; then
+        echo "Adding /etc/monit/conf.d/ to the monit config ($MONITRC)" >&2
+        echo 'include /etc/monit/conf.d/*.conf' >> "$MONITRC"
+    fi
+fi
+
+add_config_if_valid() {
+    #
+    # Only add a configuration file if it is accepted by monit
+    # It is verified by adding the config file, running "monit -t", and removing the config file if the test fails
+    #
+    CONF_FILE="$1"
+    if [ $# -gt 1 ]; then
+        name="$2"
+    else
+        name=$(basename "$CONF_FILE")
+    fi
+
+    if monit -c "$MONITRC" -t >/dev/null 2>&1; then
+        ln -sf "$CONF_FILE" "/etc/monit/conf.d/$name"
+        if ! monit -c "$MONITRC" -t; then
+            echo "Warning: Excluding $name as the monit version does not support the syntax used in it"
+            rm -f "/etc/monit/conf.d/$name"
+            return 1
+        fi
+    fi
+    return 0
+}
+
+# Add configuration
+if [ -f "$MONITRC" ]; then
+    if ! add_config_if_valid /usr/share/tedge-monit-setup/tedge-monitoring.conf "tedge-monitoring.conf"; then
+        add_config_if_valid /usr/share/tedge-monit-setup/tedge-monitoring-legacy.conf "tedge-monitoring.conf" ||:
     fi
 fi
 

--- a/src/packaging/postremove
+++ b/src/packaging/postremove
@@ -16,6 +16,7 @@ do_initd() {
 remove_or_purge() {
     rm -f /etc/monit/conf.d/tedge-monitoring-extended.conf
     rm -f /usr/share/tedge-monit-setup/tedge-monitoring-legacy.conf
+    rm -f /etc/systemd/system/monit.service
 
     if command -V systemctl >/dev/null 2>&1; then
         do_systemd

--- a/src/packaging/postremove
+++ b/src/packaging/postremove
@@ -13,8 +13,29 @@ do_initd() {
     service monit stop ||:
 }
 
-if command -V systemctl >/dev/null 2>&1; then
-    do_systemd
-else
-    do_initd
-fi
+remove_or_purge() {
+    rm -f /etc/monit/conf.d/tedge-monitoring-extended.conf
+    rm -f /usr/share/tedge-monit-setup/tedge-monitoring-legacy.conf
+
+    if command -V systemctl >/dev/null 2>&1; then
+        do_systemd
+    else
+        do_initd
+    fi
+}
+
+action="$1"
+case "$action" in
+  "0" | "remove")
+    remove_or_purge
+    ;;
+  "1" | "upgrade")
+    # Do nothing on upgrade
+    ;;
+  "purge")
+    remove_or_purge
+    ;;
+  *)
+    remove_or_purge
+    ;;
+esac

--- a/src/service/monit.service
+++ b/src/service/monit.service
@@ -1,0 +1,36 @@
+[Unit]
+Description=Pro-active monitoring utility for unix systems
+After=network-online.target
+Documentation=man:monit(1) https://mmonit.com/wiki/Monit/HowTo
+
+[Service]
+Type=simple
+KillMode=process
+ExecStart=/usr/bin/monit -I
+ExecStop=/usr/bin/monit quit
+ExecReload=/usr/bin/monit reload
+Restart=on-abnormal
+StandardOutput=null
+
+# hardening options
+#  details: https://www.freedesktop.org/software/systemd/man/systemd.exec.html
+CapabilityBoundingSet=~CAP_SYS_ADMIN
+LockPersonality=true
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHome=yes
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectSystem=strict
+ReadWritePaths=/run/ /var/lib/monit/ /var/log/ /etc/tedge/ /opt/tedge-monit/
+RestrictRealtime=true
+RestrictSUIDSGID=true
+SystemCallArchitectures=native
+
+[Install]
+WantedBy=multi-user.target

--- a/test-images/ubuntu-20.04/Dockerfile
+++ b/test-images/ubuntu-20.04/Dockerfile
@@ -1,0 +1,40 @@
+FROM ubuntu:20.04
+
+# Install
+RUN apt-get -y update \
+    && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
+    wget \
+    curl \
+    gnupg2 \
+    sudo \
+    apt-transport-https \
+    ca-certificates \
+    ssh \
+    systemd \
+    dbus \
+    systemd-sysv
+
+# Remove unnecessary systemd services
+RUN rm -f /lib/systemd/system/multi-user.target.wants/* \
+    /etc/systemd/system/*.wants/* \
+    /lib/systemd/system/local-fs.target.wants/* \
+    /lib/systemd/system/sockets.target.wants/*udev* \
+    /lib/systemd/system/sockets.target.wants/*initctl* \
+    /lib/systemd/system/systemd-update-utmp* \
+    # Remove policy-rc.d file which prevents services from starting
+    && rm -f /usr/sbin/policy-rc.d
+
+RUN wget -O - https://thin-edge.io/install.sh | sh -s
+
+COPY test-images/debian-11/bootstrap.sh /usr/bin/
+
+WORKDIR /build
+
+COPY dist/tedge-monit-setup_*.deb .
+RUN apt-get install -y --no-install-recommends ./tedge-monit-setup_*.deb
+
+# Reference: https://developers.redhat.com/blog/2019/04/24/how-to-run-systemd-in-a-container#enter_podman
+# STOPSIGNAL SIGRTMIN+3 (=37)
+STOPSIGNAL 37
+
+CMD ["/lib/systemd/systemd"]

--- a/test-images/ubuntu-22.04/Dockerfile
+++ b/test-images/ubuntu-22.04/Dockerfile
@@ -1,0 +1,40 @@
+FROM ubuntu:22.04
+
+# Install
+RUN apt-get -y update \
+    && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
+    wget \
+    curl \
+    gnupg2 \
+    sudo \
+    apt-transport-https \
+    ca-certificates \
+    ssh \
+    systemd \
+    dbus \
+    systemd-sysv
+
+# Remove unnecessary systemd services
+RUN rm -f /lib/systemd/system/multi-user.target.wants/* \
+    /etc/systemd/system/*.wants/* \
+    /lib/systemd/system/local-fs.target.wants/* \
+    /lib/systemd/system/sockets.target.wants/*udev* \
+    /lib/systemd/system/sockets.target.wants/*initctl* \
+    /lib/systemd/system/systemd-update-utmp* \
+    # Remove policy-rc.d file which prevents services from starting
+    && rm -f /usr/sbin/policy-rc.d
+
+RUN wget -O - https://thin-edge.io/install.sh | sh -s
+
+COPY test-images/debian-11/bootstrap.sh /usr/bin/
+
+WORKDIR /build
+
+COPY dist/tedge-monit-setup_*.deb .
+RUN apt-get install -y --no-install-recommends ./tedge-monit-setup_*.deb
+
+# Reference: https://developers.redhat.com/blog/2019/04/24/how-to-run-systemd-in-a-container#enter_podman
+# STOPSIGNAL SIGRTMIN+3 (=37)
+STOPSIGNAL 37
+
+CMD ["/lib/systemd/systemd"]

--- a/test-images/ubuntu-24.04/Dockerfile
+++ b/test-images/ubuntu-24.04/Dockerfile
@@ -1,0 +1,40 @@
+FROM ubuntu:24.04
+
+# Install
+RUN apt-get -y update \
+    && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
+    wget \
+    curl \
+    gnupg2 \
+    sudo \
+    apt-transport-https \
+    ca-certificates \
+    ssh \
+    systemd \
+    dbus \
+    systemd-sysv
+
+# Remove unnecessary systemd services
+RUN rm -f /lib/systemd/system/multi-user.target.wants/* \
+    /etc/systemd/system/*.wants/* \
+    /lib/systemd/system/local-fs.target.wants/* \
+    /lib/systemd/system/sockets.target.wants/*udev* \
+    /lib/systemd/system/sockets.target.wants/*initctl* \
+    /lib/systemd/system/systemd-update-utmp* \
+    # Remove policy-rc.d file which prevents services from starting
+    && rm -f /usr/sbin/policy-rc.d
+
+RUN wget -O - https://thin-edge.io/install.sh | sh -s
+
+COPY test-images/debian-11/bootstrap.sh /usr/bin/
+
+WORKDIR /build
+
+COPY dist/tedge-monit-setup_*.deb .
+RUN apt-get install -y --no-install-recommends ./tedge-monit-setup_*.deb
+
+# Reference: https://developers.redhat.com/blog/2019/04/24/how-to-run-systemd-in-a-container#enter_podman
+# STOPSIGNAL SIGRTMIN+3 (=37)
+STOPSIGNAL 37
+
+CMD ["/lib/systemd/systemd"]


### PR DESCRIPTION
Add support for Ubuntu-20.04 and 24.04
* Ubuntu 20.04 - Only add filedescriptor check after it monit has been checked if it is supported or not
* Ubuntu 24.04 - check monit.service definition if it has systemd "hardening" and if detected use a custom monit.service which is compatible with the tedge reconnect command