### PR TITLE
fix(install): check if systemd service definition exists first

### DIFF
--- a/src/packaging/postinstall
+++ b/src/packaging/postinstall
@@ -62,10 +62,12 @@ fi
 
 # newer monit service definitions are sometimes too strict on the "hardening" of the service
 # which results in the "tedge reconnect c8y" command failing.
-if grep -q "CapabilityBoundingSet=" /usr/lib/systemd/system/monit.service; then
-    if [ ! -e /etc/systemd/system/monit.service ]; then
-        echo "Using custom monit.service definition with custom capabilities set"
-        ln -sf /usr/share/tedge-monit-setup/service/monit.service /etc/systemd/system/monit.service
+if [ -f /usr/lib/systemd/system/monit.service ]; then
+    if grep -q "CapabilityBoundingSet=" /usr/lib/systemd/system/monit.service; then
+        if [ ! -e /etc/systemd/system/monit.service ]; then
+            echo "Using custom monit.service definition with custom capabilities set"
+            ln -sf /usr/share/tedge-monit-setup/service/monit.service /etc/systemd/system/monit.service
+        fi
     fi
 fi
 


### PR DESCRIPTION
The following error is printed on the console when install the the debian linux package which might cause users to be concerned that something didn't work.

```
grep: /usr/lib/systemd/system/monit.service: No such file or directory
```

Before running the grep, the systemd service is existence is first checked avoiding the error.