### PR TITLE
fix(install): remove default monitrc line which causes service to fail

### DIFF
--- a/src/packaging/postinstall
+++ b/src/packaging/postinstall
@@ -24,6 +24,12 @@ fi
 # In Yocto, monit looks at the /etc/monit.d/ directory
 # instead of /etc/monit/conf.d/, so let's add the other directory to as well (for normalization)
 if [ -f "$MONITRC" ]; then
+
+    # Some debian packages (maybe a Raspberry Pi APT mirror, monit 5.33.0) includes a buggy
+    # default monitrc configuration where the line 'include /etc/monit/conf.d/*' causes the service not to start.
+    # So delete the line as it will be replaced with a similar line afterwards
+    sed -i 's|^include /etc/monit/conf.d/\*$||g' "$MONITRC"
+
     if ! grep -q "include /etc/monit/conf.d/\*" "$MONITRC"; then
         echo "Adding /etc/monit/conf.d/ to the monit config ($MONITRC)" >&2
         echo 'include /etc/monit/conf.d/*.conf' >> "$MONITRC"


### PR DESCRIPTION
Fix a bug where the default monitrc configuration file for some debian packages (maybe the Raspberry Pi debian mirror?) where the monitrc has invalid configuration which causes the service to fail to start-up.

The postinstallation script now fixes the buggy configuration by default to ensure the service can start as normal.