### PR TITLE
feat: restart mosquitto if port 1883 is not reachable

### DIFF
--- a/src/conf.d/tedge-monitoring.conf
+++ b/src/conf.d/tedge-monitoring.conf
@@ -16,6 +16,7 @@ check system $HOST
 # always used in all installations
 check process mosquitto MATCHING "mosquitto -c .+"
     if failed port 1883 protocol mqtt then alert
+    if failed port 1883 protocol mqtt for 2 cycles then exec "/usr/bin/systemctl restart mosquitto"
 
 # Note: the tedge-agent memory usage can spike when using package managed such as apt as
 # they generally require a lot of memory (>100MB) if you access the indexes from any public software


### PR DESCRIPTION
Add rule to restart mosquitto if port 1883 is not reachable. If port 1883 is unrechable it indicates that mosquitto is not functional and restarting it can fix it.