### PR TITLE
fix: avoid using wildcard in include folder syntax

### DIFF
--- a/src/packaging/postinstall
+++ b/src/packaging/postinstall
@@ -30,9 +30,9 @@ if [ -f "$MONITRC" ]; then
     # So delete the line as it will be replaced with a similar line afterwards
     sed -i 's|^include /etc/monit/conf.d/\*$||g' "$MONITRC"
 
-    if ! grep -q "include /etc/monit/conf.d/\*" "$MONITRC"; then
+    if ! grep -q "include /etc/monit/conf.d/" "$MONITRC"; then
         echo "Adding /etc/monit/conf.d/ to the monit config ($MONITRC)" >&2
-        echo 'include /etc/monit/conf.d/*.conf' >> "$MONITRC"
+        echo 'include /etc/monit/conf.d/' >> "$MONITRC"
     fi
 fi
 


### PR DESCRIPTION
Older monit versions (e.g. default version 5.27.2 in debian bullseye) interpret the wildcard `*` as a literal char, and it causes the service to not start.