### PR TITLE
fix: invalid symlink due to conf being marked as config

### DIFF
--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -17,7 +17,6 @@ apk:
 contents:
   - src: ./src/conf.d/*.conf
     dst: /usr/share/tedge-monit-setup/
-    type: config
     file_info:
       mode: 0644
       group: tedge


### PR DESCRIPTION
Fixing an issue where the symlink from `/etc/monit/conf.d/tedge.conf` to `/usr/share/tedge-monit-setup/tedge.conf` would point to a non-existent file as the /usr/share files were marked as "config" in the nfpm configuration which resulted in the dpkg adding the `.dpkg-new` suffix to the files names.

Resolves https://github.com/thin-edge/tedge-monit-setup/issues/35