### PR TITLE
test: fix debian-12 image and allow package downgrades in tests

### DIFF
--- a/test-images/debian-12/Dockerfile
+++ b/test-images/debian-12/Dockerfile
@@ -9,4 +9,4 @@ RUN tedge config unset c8y.proxy.client.host \
     && tedge config unset http.client.host
 
 COPY dist/tedge-monit-setup*.deb /tmp/
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends /tmp/*.deb
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --allow-downgrades /tmp/*.deb


### PR DESCRIPTION
The system tests for debian-12 would fail due to the missing `--allow-downgrades` argument when installing the current build as the package is also included in the tedge demo container by default, so technically it would be a "downgrade" because the package's version used in the tests is fixed at 0.0.0.