### PR TITLE
ci: refactor test setup

### DIFF
--- a/.github/workflows/test-slash-command.yaml
+++ b/.github/workflows/test-slash-command.yaml
@@ -1,0 +1,25 @@
+name: Test (Slash Command)
+
+# Listens for /test comments on pull requests.
+# issue_comment always runs in the base-repo context, so this workflow has
+# access to repository secrets even for fork PRs.
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+jobs:
+  slash-command-dispatch:
+    name: Dispatch /test command
+    if: github.event.issue.pull_request != null
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v5
+        with:
+          token: ${{ secrets.COMMUNITY_ACTIONS_PAT }}
+          commands: test
+          permission: write
+          issue-type: pull-request

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,38 +1,68 @@
 name: Test
 
 on:
-  workflow_dispatch:
-  # Use a manual approval process before PR's are given access to
-  # the secrets which are required to run the integration tests.
-  # The PR code should be manually approved to see if it can be trusted.
-  # When in doubt, do not approve the test run.
-  # Reference: https://dev.to/petrsvihlik/using-environment-protection-rules-to-secure-secrets-when-building-external-forks-with-pullrequesttarget-hci
-  pull_request_target:
+  # In-repo (maintainer) PRs run automatically. Fork PRs lack secret access and
+  # must be triggered by a maintainer commenting /test (see test-slash-command.yaml).
+  pull_request:
     branches: [ main ]
+  repository_dispatch:
+    types: [test-command]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Commit SHA or branch to test"
+        required: false
+        default: ""
   merge_group:
+
+permissions:
+  contents: read
+
 jobs:
-  approve:
-    name: Approve
-    environment:
-      # For security reasons, all pull requests need to be approved first before granting access to secrets
-      # So the environment should be set to have a reviewer/s inspect it before approving it
-      name: ${{ github.event_name == 'pull_request_target' && 'Test Pull Request' || 'Test Auto'  }}
+  build:
+    name: Build
+    # Skip fork PRs on the pull_request event (they have no secret access); the
+    # /test slash command path handles fork PRs via repository_dispatch instead.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - name: Wait for approval
-        run: echo "Approved"
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.client_payload.pull_request.head.sha || inputs.ref || github.sha }}
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+          cache: false
+      - name: Install dependencies
+        run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
+
+      - uses: taiki-e/install-action@just
+
+      - name: Build package
+        run: just build
+
+      - name: Upload packages
+        uses: actions/upload-artifact@v7
+        with:
+          name: dist-packages
+          path: dist/
 
   test:
-    name: Test
-    needs: [approve]
+    name: Test ${{ matrix.job.image }}
+    needs: [build]
+    runs-on: ubuntu-latest
     permissions:
+      contents: read
+      issues: write
       pull-requests: write
     environment:
       name: Test Auto
-    runs-on: ubuntu-latest
     env:
-      COMPOSE_PROJECT_NAME: ci_${{github.run_id}}_${{github.run_attempt || '1'}}
-      IMAGE: ${{ matrix.job.image }}_ci_${{github.run_id}}_${{github.run_attempt || '1'}}
+      IMAGE: ${{ matrix.job.image }}_ci_${{ github.run_id }}_${{ github.run_attempt || '1' }}
       IMAGE_SRC: ${{ matrix.job.image }}
 
     strategy:
@@ -49,14 +79,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
+          ref: ${{ github.event.client_payload.pull_request.head.sha || inputs.ref || github.sha }}
+
+      - name: Download packages
+        uses: actions/download-artifact@v8
+        with:
+          name: dist-packages
+          path: dist/
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
 
       - name: create .env file
         run: |
-          touch .env
-          echo 'C8Y_BASEURL="${{ secrets.C8Y_BASEURL }}"' >> .env
-          echo 'C8Y_USER="${{ secrets.C8Y_USER }}"' >> .env
-          echo 'C8Y_PASSWORD="${{ secrets.C8Y_PASSWORD }}"' >> .env
+          {
+            echo 'C8Y_BASEURL="${{ secrets.C8Y_BASEURL }}"'
+            echo 'C8Y_USER="${{ secrets.C8Y_USER }}"'
+            echo 'C8Y_PASSWORD="${{ secrets.C8Y_PASSWORD }}"'
+          } >> .env
 
       - uses: actions/setup-python@v6
         with:
@@ -67,21 +107,6 @@ jobs:
 
       - uses: taiki-e/install-action@just
 
-      #
-      # Build
-      #
-      - uses: actions/setup-go@v6
-        with:
-          go-version: stable
-          cache: false
-      - name: Install dependencies
-        run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
-      - name: Build package (for testing)
-        run: just build
-
-      #
-      # Test
-      #
       - name: Install dependencies
         run: |
           just venv
@@ -98,8 +123,27 @@ jobs:
           path: output
 
       - name: Send report to commit
-        if: ${{ always() && github.event_name == 'pull_request_target' }}
+        if: ${{ always() && (github.event_name == 'pull_request' || github.event_name == 'repository_dispatch') }}
         uses: "joonvena/robotframework-reporter-action@v2.5"
         with:
           report_path: output
           gh_access_token: ${{ secrets.GITHUB_TOKEN }}
+          pull_request_id: ${{ github.event.pull_request.number || github.event.client_payload.pull_request.number }}
+          sha: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
+
+  tests-pass:
+    name: Tests Pass
+    needs: [build, test]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all matrix jobs passed
+        run: |
+          if [ "${{ needs.build.result }}" != "success" ]; then
+            echo "Build job failed: ${{ needs.build.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "One or more matrix jobs failed: ${{ needs.test.result }}"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Modernizes the integration-test CI to the pattern established in [thin-edge/tedge-apk-plugin#5](https://github.com/thin-edge/tedge-apk-plugin/pull/5), making fork PRs safe to test without the legacy `pull_request_target` + manual GitHub Environment approval dance.

The Robot Framework tests in this repo already use per-test device setup (`DeviceLibrary.Setup`), the `justfile` is already free of `docker compose` demo targets, and `tests/.python-version` already exists — so this change is scoped to the GitHub Actions workflows.

### What changed

**New `/test` slash-command workflow** (`.github/workflows/test-slash-command.yaml`)
- Listens for `/test` comments on PRs. `issue_comment` runs in the base-repo context, so it has secret access even for fork PRs, and dispatches a `repository_dispatch` (`test-command`) event only when a maintainer with write permission comments `/test`.

**Refactored `test.yaml`** into `build` → `test` (matrix) → `tests-pass`
- Triggers: `pull_request` (in-repo PRs run automatically), `repository_dispatch` (fork PRs via `/test`), `workflow_dispatch`, and `merge_group`. The `pull_request_target` trigger and the manual `approve` job are removed.
- The `build` job skips fork PRs on the `pull_request` event (they have no secrets — the `/test` path handles them), packages once with `nfpm`, and uploads `dist/` as the `dist-packages` artifact.
- The `test` matrix (debian-11/12, ubuntu-20.04/22.04/24.04) downloads the packages instead of rebuilding per image, builds the per-image test container, runs the tests, and reports results back to the PR.
- `tests-pass` is a stable branch-protection gate that fails if the build or any matrix job failed.

### Action versions
Pinned to current latest majors: `slash-command-dispatch@v5`, `setup-buildx-action@v4`, `download-artifact@v8`, `upload-artifact@v7`.

## :warning: Required follow-up for the repo owner

1. **Add a `COMMUNITY_ACTIONS_PAT` secret** — a repo-scoped PAT with `write` access. The default `GITHUB_TOKEN` cannot create `repository_dispatch` events, so the `/test` slash command will not work without it.
2. **Update branch protection** — require the **`Tests Pass`** status check (the matrix job names change, this gate is stable). The old `Test` required check can be dropped.

## How fork PRs work now
- In-repo (maintainer) PRs: tests run automatically.
- Fork PRs: a maintainer reviews the diff and comments `/test` to run the suite.

## Verification
- `actionlint` passes on both workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)